### PR TITLE
bug fix

### DIFF
--- a/2 - Software Engineering (SE)/Week 11/1 - Theory and Practical/3 - Wednesday/Practical/readme.md
+++ b/2 - Software Engineering (SE)/Week 11/1 - Theory and Practical/3 - Wednesday/Practical/readme.md
@@ -35,15 +35,15 @@ virtualenv==x.x.x
 # Linux
 sudo apt-get install python3-venv    # If needed
 python3 -m venv .django_venv
-source .venv/bin/activate
+source .django_venv/bin/activate
 
 # macOS
 python3 -m venv .django_venv
-source .venv/bin/activate
+source .django_venv/bin/activate
 
 # Windows
 py -m venv .django_venv
-.venv\scripts\activate
+.django_venv\scripts\activate
 ```
 
 Once activated, your terminal prompt should look like this:


### PR DESCRIPTION
bug fix: The terminal command to activate the virtual environment is wrong. The assigned virtual environment folder name is ".django_venv/bin/activate" therefore this is the name that should be used when activating the virtual environment instead of ".venv/bin/activate". This fixed the bug I was having, and I assume others may have the same issue.